### PR TITLE
Fixed KSP Log Warnings

### DIFF
--- a/gcherry/log.py
+++ b/gcherry/log.py
@@ -884,7 +884,7 @@ class LogAnalyzer:
     def _common_error_values(self):
         # NOTE: Should be dataframe, but currently oe is stored as array.
         df_prob = self.guidance_log.problem.dataframe_log()
-        query_t = df_prob['inputs']['pitch_heading_query.query_t']
+        query_t = np.unique(df_prob['inputs']['pitch_heading_query.query_t'])
         df_deriv = self.get_derived_values(
             t_interp=query_t)
         input_prob_dict = {

--- a/gcherry/main_script.py
+++ b/gcherry/main_script.py
@@ -88,8 +88,9 @@ def _save_log(config: cfg.Config, guidance_obj: GuidanceBase, sim_obj, log_obj: 
 def _plot_log(log_obj: LogAnalyzer):
     log_obj.plot_inputs()
     log_obj.plot_outputs()
-    log_obj.plot_error()
     log_obj.plot_derived()
+    log_obj.plot_error()
+    log_obj.plot_final_error(tspan=0.2)
     plt.show()
 
 

--- a/gcherry/sim_interface.py
+++ b/gcherry/sim_interface.py
@@ -309,42 +309,29 @@ class KRPCClient(SingleStageSimulatorBase):
 
     @override
     def run(self):
-        init_time = self._conn.space_center.ut
-        # guidance must start at time 0
-        guidance_time = 0
-        state = self._get_state()
-        # call get_command to initialize outer loop solution
-        self.guidance_obj.get_command(
-                        0, state, outer_loop=True, log=True)
-        self._mark_outer_loop_calc(guidance_time)
-        estimated_T = self.guidance_obj.estimated_final_time()
-
         # Default initial pitch and heading
         self._vessel.auto_pilot.attenuation_angle = (0.01, 0.01, 0.01)
         self._vessel.auto_pilot.target_pitch_and_heading(90, 90)
         self._vessel.auto_pilot.target_roll = 0
         self._vessel.auto_pilot.engage()
         self._vessel.control.throttle = 1
+
+        init_time = self._conn.space_center.ut
+        # guidance must start at time 0
+        guidance_time = 0
+        state = self._get_state()
+        # call get_command to initialize outer loop solution
+        thrust_cmd, pitch_cmd, heading_cmd = self.guidance_obj.get_command(
+                        0, state, outer_loop=True, log=False)
+        self._mark_outer_loop_calc(guidance_time)
+        estimated_T = self.guidance_obj.estimated_final_time()
  
         while guidance_time < estimated_T + self._post_guidance_measurement:
             state = self._get_state()
             self._log_state(state, guidance_time)
 
-            #TODO: move this to private function
             self.guidance_obj.set_thrust_acc_measurement(guidance_time, self._get_thrust_acc())
-            if (not self._is_outer_loop_cutoff(guidance_time) and 
-                self._is_outer_loop_scheduled(guidance_time)):
-                thrust_cmd, pitch_cmd, heading_cmd = (
-                    self.guidance_obj.get_command(
-                        guidance_time, state, outer_loop=True, log=True, 
-                        mecoshift=self._main_engine_cutoff_shift))
-                self._mark_outer_loop_calc(guidance_time)
-                print("Outer Loop Calculated")
-            else:
-                thrust_cmd, pitch_cmd, heading_cmd = (
-                    self.guidance_obj.get_command(
-                        guidance_time, state, outer_loop=False, log=True,
-                        mecoshift=self._main_engine_cutoff_shift))
+            thrust_cmd, pitch_cmd, heading_cmd = self._get_guidance_command(guidance_time, state)
 
             self._vessel.control.throttle = thrust_cmd
             self._vessel.auto_pilot.target_pitch_and_heading(
@@ -365,6 +352,22 @@ class KRPCClient(SingleStageSimulatorBase):
         
         self._vessel.control.throttle = 0
         self._vessel.auto_pilot.disengage()
+
+    def _get_guidance_command(self, guidance_time, state):
+        if (not self._is_outer_loop_cutoff(guidance_time) and 
+            self._is_outer_loop_scheduled(guidance_time)):
+            thrust_cmd, pitch_cmd, heading_cmd = (
+                self.guidance_obj.get_command(
+                    guidance_time, state, outer_loop=True, log=True, 
+                    mecoshift=self._main_engine_cutoff_shift))
+            self._mark_outer_loop_calc(guidance_time)
+            print("Outer Loop Calculated")
+        else:
+            thrust_cmd, pitch_cmd, heading_cmd = (
+                self.guidance_obj.get_command(
+                    guidance_time, state, outer_loop=False, log=True,
+                    mecoshift=self._main_engine_cutoff_shift))
+        return thrust_cmd, pitch_cmd, heading_cmd
 
     def _get_thrust_acc(self):
         return self._streams['thrust']()/self._streams['mass']()


### PR DESCRIPTION
Removed numpy warnings when using the LogAnalyzer on KRPC logs, and moved the `get_command()` logic in `KRPCClient` into its own function.